### PR TITLE
Hide properties of embedded objects

### DIFF
--- a/src/JsonTransformer.php
+++ b/src/JsonTransformer.php
@@ -205,6 +205,8 @@ class JsonTransformer extends Transformer implements HalTransformer
         if (!empty($value[Serializer::CLASS_IDENTIFIER_KEY])) {
             $type = $value[Serializer::CLASS_IDENTIFIER_KEY];
             if (\is_scalar($type) && !empty($this->mappings[$type])) {
+                RecursiveDeleteHelper::deleteProperties($this->mappings, $value, $type);
+
                 $idProperties = $this->mappings[$type]->getIdProperties();
                 CuriesHelper::addCurieForResource($this->mappings, $this->curies, $type);
 

--- a/tests/Dummy/ComplexObject/User.php
+++ b/tests/Dummy/ComplexObject/User.php
@@ -25,13 +25,19 @@ class User
     private $name;
 
     /**
+     * @var
+     */
+    private $password;
+
+    /**
      * @param UserId $id
      * @param $name
      */
-    public function __construct(UserId $id, $name)
+    public function __construct(UserId $id, $name, $password)
     {
         $this->userId = $id;
         $this->name = $name;
+        $this->password = $password;
     }
 
     /**
@@ -48,5 +54,13 @@ class User
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPassword()
+    {
+        return $this->password;
     }
 }

--- a/tests/JsonTransformerTest.php
+++ b/tests/JsonTransformerTest.php
@@ -198,7 +198,9 @@ JSON;
                 'class' => User::class,
                 'alias' => '',
                 'aliased_properties' => [],
-                'hide_properties' => [],
+                'hide_properties' => [
+                    'password',
+                ],
                 'id_properties' => [
                     'userId',
                 ],
@@ -330,13 +332,14 @@ JSON;
             'Your first post',
             new User(
                 new UserId(1),
-                'Post Author'
+                'Post Author',
+                'ilovemyjob'
             ),
             [
                 new Comment(
                     new CommentId(1000),
                     'Have no fear, sers, your king is safe.',
-                    new User(new UserId(2), 'Barristan Selmy'),
+                    new User(new UserId(2), 'Barristan Selmy', 'ilovemyjob'),
                     [
                         'created_at' => (new DateTime('2015-07-18T12:13:00+00:00'))->format('c'),
                         'accepted_at' => (new DateTime('2015-07-19T00:00:00+00:00'))->format('c'),
@@ -725,7 +728,9 @@ JSON;
                 'class' => User::class,
                 'alias' => '',
                 'aliased_properties' => [],
-                'hide_properties' => [],
+                'hide_properties' => [
+                    'password',
+                ],
                 'id_properties' => [
                     'userId',
                 ],
@@ -816,13 +821,14 @@ JSON;
             'Your first post',
             new User(
                 new UserId(1),
-                'Post Author'
+                'Post Author',
+                'ilovemyjob'
             ),
             [
                 new Comment(
                     new CommentId(1000),
                     'Have no fear, sers, your king is safe.',
-                    new User(new UserId(2), 'Barristan Selmy'),
+                    new User(new UserId(2), 'Barristan Selmy', 'ilovemyjob'),
                     [
                         'created_at' => (new DateTime('2015-07-18T12:13:00+00:00'))->format('c'),
                         'accepted_at' => (new DateTime('2015-07-19T00:00:00+00:00'))->format('c'),

--- a/tests/XmlTransformerTest.php
+++ b/tests/XmlTransformerTest.php
@@ -178,7 +178,9 @@ XML;
                 'class' => User::class,
                 'alias' => '',
                 'aliased_properties' => [],
-                'hide_properties' => [],
+                'hide_properties' => [
+                    'password',
+                ],
                 'id_properties' => [
                     'userId',
                 ],
@@ -302,13 +304,14 @@ XML;
             'Your first post',
             new User(
                 new UserId(1),
-                'Post Author'
+                'Post Author',
+                'ilovemyjob'
             ),
             [
                 new Comment(
                     new CommentId(1000),
                     'Have no fear, sers, your king is safe.',
-                    new User(new UserId(2), 'Barristan Selmy'),
+                    new User(new UserId(2), 'Barristan Selmy', 'ilovemyjob'),
                     [
                         'created_at' => (new DateTime('2015-07-18T12:13:00+00:00'))->format('c'),
                         'accepted_at' => (new DateTime('2015-07-19T00:00:00+00:00'))->format('c'),


### PR DESCRIPTION
Hi Nil, 

I modified `JsonTransformer` to hide properties in embedded objects according to the mapping. 

I'd expect that to be the default behavior, but I couldn't configure the mapper to do this.

Let me know if there's a way to do it without having to change your code.

Thank you!